### PR TITLE
Silence DMA buffer on pause/stop and reprogram stream descriptor when resuming

### DIFF
--- a/minwave.cpp
+++ b/minwave.cpp
@@ -1434,10 +1434,30 @@ SetState
             {
                 Miniport->AdapterCommon->hda_stop_sound();
             }
+            if (DmaChannel)
+            {
+                Silence(DmaChannel->SystemAddress(), DmaChannel->BufferSize());
+            }
             break;
 
         case KSSTATE_RUN:
             {
+                // Reprogram the stream descriptor before resuming from pause.
+                // hda_stop_sound() only clears RUN and leaves the stream
+                // descriptor/LPIB state intact; resuming with the hardware
+                // pointer near the end of the cyclic buffer can let the DMA
+                // engine wrap into stale data before PortCls refills it, which
+                // presents as choppy or silent playback.  Recreating the
+                // descriptor mirrors the stop/start path that avoids this.
+                if (State == KSSTATE_PAUSE && DmaChannel)
+                {
+                    ntStatus = Miniport->AdapterCommon->hda_setup_stream_descriptor(DmaChannel);
+                    if (!NT_SUCCESS(ntStatus))
+                    {
+                        break;
+                    }
+                }
+
                 // Start DMA.
 				Miniport->AdapterCommon->hda_start_sound();
             }
@@ -1445,6 +1465,10 @@ SetState
 
         case KSSTATE_STOP:
 			// fill buffer with silence
+            if (DmaChannel)
+            {
+                Silence(DmaChannel->SystemAddress(), DmaChannel->BufferSize());
+            }
             break;
         }
 


### PR DESCRIPTION
### Motivation
- Prevent choppy or silent playback caused by stale data in the cyclic DMA buffer when transitioning between `KSSTATE_RUN`, `KSSTATE_PAUSE`, and `KSSTATE_STOP`.
- Ensure the hardware stream descriptor/LPIB is in a known good state when resuming from pause to avoid the DMA engine wrapping into old data.

### Description
- When transitioning to `KSSTATE_PAUSE`, zero the DMA buffer by calling `Silence(DmaChannel->SystemAddress(), DmaChannel->BufferSize())` if `DmaChannel` exists.
- When transitioning from `KSSTATE_PAUSE` back to `KSSTATE_RUN`, reprogram the stream descriptor by calling `hda_setup_stream_descriptor(DmaChannel)` before starting DMA, and abort the transition on failure.
- When transitioning to `KSSTATE_STOP`, fill the DMA buffer with silence using the same `Silence(...)` call when `DmaChannel` exists.
- Kept the `Silence` implementation which fills the buffer with the appropriate silence pattern based on `Format16Bit`.

### Testing
- Performed an automated build of the project (`msbuild`/build system); the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ed4e77120832399f3740bddab7fb6)