### PR TITLE
Add master mute control and mute-aware volume/gain APIs

### DIFF
--- a/codec.cpp
+++ b/codec.cpp
@@ -556,7 +556,7 @@ STDMETHODIMP_(NTSTATUS) HDA_Codec::hda_initialize_output_pin ( ULONG pin_node_nu
 
 	//set maximal volume for PIN
 	ULONG pin_output_amp_capabilities = hda_send_verb(pin_node_number, 0xF00, 0x12);
-	hda_set_node_gain(pin_node_number, HDA_OUTPUT_NODE, pin_output_amp_capabilities, 250, 3);
+	hda_set_node_gain(pin_node_number, HDA_OUTPUT_NODE, pin_output_amp_capabilities, 250, 3, FALSE);
 	if(pin_output_amp_capabilities != 0) {
 		//we will control volume by PIN node
 		path.output_amp_node_number = pin_node_number;
@@ -616,7 +616,7 @@ STDMETHODIMP_(void) HDA_Codec::hda_initialize_audio_output(ULONG output_node_num
 
 	//set maximum volume for Audio Output
 	ULONG audio_output_amp_capabilities = hda_send_verb(output_node_number, 0xF00, 0x12);
-	hda_set_node_gain(output_node_number, HDA_OUTPUT_NODE, audio_output_amp_capabilities, 250, 3);
+	hda_set_node_gain(output_node_number, HDA_OUTPUT_NODE, audio_output_amp_capabilities, 250, 3, FALSE);
 	if(audio_output_amp_capabilities != 0) {
 		//we will control volume by Audio Output node
 		path.output_amp_node_number = output_node_number;
@@ -677,7 +677,7 @@ STDMETHODIMP_(void) HDA_Codec::hda_initialize_audio_mixer(ULONG audio_mixer_node
 
 	//set maximal volume for Audio Mixer
 	ULONG audio_mixer_amp_capabilities = hda_send_verb(audio_mixer_node_number, 0xF00, 0x12);
-	hda_set_node_gain(audio_mixer_node_number, HDA_OUTPUT_NODE, audio_mixer_amp_capabilities, 250, 3);
+	hda_set_node_gain(audio_mixer_node_number, HDA_OUTPUT_NODE, audio_mixer_amp_capabilities, 250, 3, FALSE);
 	if(audio_mixer_amp_capabilities != 0) {
 		//we will control volume by Audio Mixer node
 		path.output_amp_node_number = audio_mixer_node_number;
@@ -733,7 +733,7 @@ STDMETHODIMP_(void) HDA_Codec::hda_initialize_audio_selector(ULONG audio_selecto
 
 	//set maximum volume for Audio Selector
 	ULONG audio_selector_amp_capabilities = hda_send_verb(audio_selector_node_number, 0xF00, 0x12);
-	hda_set_node_gain(audio_selector_node_number, HDA_OUTPUT_NODE, audio_selector_amp_capabilities, 250, 3);
+	hda_set_node_gain(audio_selector_node_number, HDA_OUTPUT_NODE, audio_selector_amp_capabilities, 250, 3, FALSE);
 	if(audio_selector_amp_capabilities != 0) {
 		//we will control volume by Audio Selector node
 		path.output_amp_node_number = audio_selector_node_number;
@@ -1105,7 +1105,7 @@ STDMETHODIMP_(UCHAR) HDA_Codec::hda_is_supported_sample_rate(ULONG sample_rate) 
 }
 
 
-STDMETHODIMP_(void) HDA_Codec::hda_set_volume(ULONG volume, UCHAR ch) {
+STDMETHODIMP_(void) HDA_Codec::hda_set_volume(ULONG volume, UCHAR ch, BOOLEAN mute) {
 
 	//go through list of output paths and set same volume on all of them
 	for (ULONG i = 0; i < out_paths.count; ++i){
@@ -1114,12 +1114,13 @@ STDMETHODIMP_(void) HDA_Codec::hda_set_volume(ULONG volume, UCHAR ch) {
 			HDA_OUTPUT_NODE, 
 			out_paths.paths[i].output_amp_node_capabilities, 
 			volume, 
-			ch
+			ch,
+			mute
 		);
 	}
 }
 
-STDMETHODIMP_(void) HDA_Codec::hda_set_node_gain(ULONG node, ULONG node_type, ULONG capabilities, ULONG gain, UCHAR ch) {
+STDMETHODIMP_(void) HDA_Codec::hda_set_node_gain(ULONG node, ULONG node_type, ULONG capabilities, ULONG gain, UCHAR ch, BOOLEAN mute) {
 	//ch bit 0: left channel bit 1: right channel
 	ch &= 3;
 	ULONG payload = ch << 12;
@@ -1132,12 +1133,10 @@ STDMETHODIMP_(void) HDA_Codec::hda_set_node_gain(ULONG node, ULONG node_type, UL
 		payload |= 0x4000;
 	}
 
-	//set number of gain
-	if(gain == 0 && (capabilities & 0x80000000) == 0x80000000) {
+	//set number of gain, preserving the codec mute bit separately
+	payload |= (((capabilities>>8) & 0x7F) * gain/256); //recalculate range
+	if(mute || (gain == 0 && (capabilities & 0x80000000) == 0x80000000)) {
 		payload |= 0x80; //mute
-	}
-	else {
-		payload |= (((capabilities>>8) & 0x7F) * gain/256); //recalculate range
 	}
 
 	//change gain

--- a/codec.h
+++ b/codec.h
@@ -187,8 +187,8 @@ public:
 	STDMETHODIMP_(void) hda_initialize_audio_mixer(ULONG audio_mixer_node_number, HDA_NODE_PATH& path);
 	STDMETHODIMP_(void) hda_initialize_audio_selector(ULONG audio_selector_node_number, HDA_NODE_PATH& path);
 	STDMETHODIMP_(BOOLEAN) hda_is_headphone_connected(void);
-	STDMETHODIMP_(void) hda_set_volume(ULONG volume, UCHAR ch);
-	STDMETHODIMP_(void) hda_set_node_gain(ULONG node, ULONG node_type, ULONG capabilities, ULONG gain, UCHAR ch);
+	STDMETHODIMP_(void) hda_set_volume(ULONG volume, UCHAR ch, BOOLEAN mute);
+	STDMETHODIMP_(void) hda_set_node_gain(ULONG node, ULONG node_type, ULONG capabilities, ULONG gain, UCHAR ch, BOOLEAN mute);
 
 	STDMETHODIMP_(void) hda_check_headphone_connection_change(void);
 	STDMETHODIMP_(UCHAR) hda_is_supported_sample_rate(ULONG sample_rate);

--- a/common.cpp
+++ b/common.cpp
@@ -330,8 +330,8 @@ public:
 	STDMETHODIMP_(UCHAR)	hda_get_node_type(ULONG codec, ULONG node);
 	STDMETHODIMP_(ULONG)	hda_get_node_connection_entries(ULONG codec, ULONG node, ULONG connection_entries_number);
 	STDMETHODIMP_(BOOLEAN)	hda_is_headphone_connected (void);
-	STDMETHODIMP_(void)		hda_set_node_gain(ULONG codec, ULONG node, ULONG node_type, ULONG capabilities, ULONG gain, UCHAR ch);
-	STDMETHODIMP_(void)		hda_set_volume(ULONG volume, UCHAR ch);
+	STDMETHODIMP_(void)		hda_set_node_gain(ULONG codec, ULONG node, ULONG node_type, ULONG capabilities, ULONG gain, UCHAR ch, BOOLEAN mute);
+	STDMETHODIMP_(void)		hda_set_volume(ULONG volume, UCHAR ch, BOOLEAN mute);
 	STDMETHODIMP_(void)		hda_start_sound (void);
 	STDMETHODIMP_(void)		hda_stop_sound (void);
 
@@ -1985,7 +1985,7 @@ MixerRegWrite
     if( m_PowerState <= PowerDeviceD1 ) {
 		if (index == 0 || index == 1) { //left or right channel respectively
 			DOUT (DBG_PRINT, ("set volume of %d to %d", index, Value));
-			hda_set_volume(Value, index + 1); //supposed to be 0-255 range
+			hda_set_volume(Value, index + 1, FALSE); //supposed to be 0-255 range
 		}
 #if (DBG)
 		if ((index == 20) && (debug_kludge == 1)){
@@ -2684,15 +2684,15 @@ STDMETHODIMP_(ULONG) CAdapterCommon::hda_get_actual_stream_position(void) {
 
 // Note: hda_set_volume has been moved to HDA_Codec class
 // For backward compatibility, delegate to all codecs
-STDMETHODIMP_(void) CAdapterCommon::hda_set_volume(ULONG volume, UCHAR ch) {
+STDMETHODIMP_(void) CAdapterCommon::hda_set_volume(ULONG volume, UCHAR ch, BOOLEAN mute) {
 	for (int i = 0; i < codecCount; i++) {
 		if (pCodecs[i] != NULL) {
-			pCodecs[i]->hda_set_volume(volume, ch);
+			pCodecs[i]->hda_set_volume(volume, ch, mute);
 		}
 	}
 }
 
-STDMETHODIMP_(void) CAdapterCommon::hda_set_node_gain(ULONG codec, ULONG node, ULONG node_type, ULONG capabilities, ULONG gain, UCHAR ch) {
+STDMETHODIMP_(void) CAdapterCommon::hda_set_node_gain(ULONG codec, ULONG node, ULONG node_type, ULONG capabilities, ULONG gain, UCHAR ch, BOOLEAN mute) {
 	//ch bit 0: left channel bit 1: right channel
 	ch &= 3;
 	ULONG payload = ch << 12;
@@ -2705,12 +2705,10 @@ STDMETHODIMP_(void) CAdapterCommon::hda_set_node_gain(ULONG codec, ULONG node, U
 		payload |= 0x4000;
 	}
 
-	//set number of gain
-	if(gain == 0 && (capabilities & 0x80000000) == 0x80000000) {
+	//set number of gain, preserving the codec mute bit separately
+	payload |= (((capabilities>>8) & 0x7F)*gain/256); //recalculate range
+	if(mute || (gain == 0 && (capabilities & 0x80000000) == 0x80000000)) {
 		payload |= 0x80; //mute
-	}
-	else {
-		payload |= (((capabilities>>8) & 0x7F)*gain/256); //recalculate range
 	}
 
 	//change gain

--- a/common.cpp
+++ b/common.cpp
@@ -330,7 +330,6 @@ public:
 	STDMETHODIMP_(UCHAR)	hda_get_node_type(ULONG codec, ULONG node);
 	STDMETHODIMP_(ULONG)	hda_get_node_connection_entries(ULONG codec, ULONG node, ULONG connection_entries_number);
 	STDMETHODIMP_(BOOLEAN)	hda_is_headphone_connected (void);
-	STDMETHODIMP_(void)		hda_set_node_gain(ULONG codec, ULONG node, ULONG node_type, ULONG capabilities, ULONG gain, UCHAR ch, BOOLEAN mute);
 	STDMETHODIMP_(void)		hda_set_volume(ULONG volume, UCHAR ch, BOOLEAN mute);
 	STDMETHODIMP_(void)		hda_start_sound (void);
 	STDMETHODIMP_(void)		hda_stop_sound (void);
@@ -1819,8 +1818,7 @@ Exit:
 //everything above this must have PAGED_CODE ();
 #pragma code_seg() 
 
-// Note: hda_check_headphone_connection_change has been moved to HDA_Codec class
-// For backward compatibility, delegate to all codecs
+// Check headphone connection status for all codecs
 STDMETHODIMP_(void) CAdapterCommon::hda_check_headphone_connection_change(void) {
 	//TODO: schedule as a periodic task DPC
 	//and make sure to clean up correctly on driver unload!
@@ -1832,8 +1830,7 @@ STDMETHODIMP_(void) CAdapterCommon::hda_check_headphone_connection_change(void) 
 }
 
 
-// Note: This function has been moved to HDA_Codec class
-// For backward compatibility, check all codecs - only return TRUE if ALL support it
+// Check if (all) codecs support the requested sample rate
 STDMETHODIMP_(UCHAR) CAdapterCommon::hda_is_supported_sample_rate(ULONG sample_rate) {
 	if (codecCount == 0) {
 		return FALSE;
@@ -1984,8 +1981,10 @@ MixerRegWrite
     // only hit the hardware if we're in an acceptable power state
     if( m_PowerState <= PowerDeviceD1 ) {
 		if (index == 0 || index == 1) { //left or right channel respectively
-			DOUT (DBG_PRINT, ("set volume of %d to %d", index, Value));
-			hda_set_volume(Value, index + 1, FALSE); //supposed to be 0-255 range
+			DOUT (DBG_PRINT, ("Set volume of %d to 0x%x", index, Value));
+			//volume values for the master channels are 5-bit (<< by 3)
+			//and mute in the LSB
+			hda_set_volume(Value & 0xF8, index + 1, Value & 1);
 		}
 #if (DBG)
 		if ((index == 20) && (debug_kludge == 1)){
@@ -2682,8 +2681,7 @@ STDMETHODIMP_(ULONG) CAdapterCommon::hda_get_actual_stream_position(void) {
 	}
 }
 
-// Note: hda_set_volume has been moved to HDA_Codec class
-// For backward compatibility, delegate to all codecs
+// Set volume & mute for all audio codecs
 STDMETHODIMP_(void) CAdapterCommon::hda_set_volume(ULONG volume, UCHAR ch, BOOLEAN mute) {
 	for (int i = 0; i < codecCount; i++) {
 		if (pCodecs[i] != NULL) {
@@ -2691,30 +2689,6 @@ STDMETHODIMP_(void) CAdapterCommon::hda_set_volume(ULONG volume, UCHAR ch, BOOLE
 		}
 	}
 }
-
-STDMETHODIMP_(void) CAdapterCommon::hda_set_node_gain(ULONG codec, ULONG node, ULONG node_type, ULONG capabilities, ULONG gain, UCHAR ch, BOOLEAN mute) {
-	//ch bit 0: left channel bit 1: right channel
-	ch &= 3;
-	ULONG payload = ch << 12;
-
-	//set type of node
-	if((node_type & HDA_OUTPUT_NODE) == HDA_OUTPUT_NODE) {
-		payload |= 0x8000;
-	}
-	if((node_type & HDA_INPUT_NODE) == HDA_INPUT_NODE) {
-		payload |= 0x4000;
-	}
-
-	//set number of gain, preserving the codec mute bit separately
-	payload |= (((capabilities>>8) & 0x7F)*gain/256); //recalculate range
-	if(mute || (gain == 0 && (capabilities & 0x80000000) == 0x80000000)) {
-		payload |= 0x80; //mute
-	}
-
-	//change gain
-	hda_send_verb(codec, node, 0x300, payload);
-}
-
 
 //HDA controller register read and write functions
 
@@ -2879,7 +2853,7 @@ STDMETHODIMP_(NTSTATUS) CAdapterCommon::hda_setup_stream_descriptor(PDMACHANNEL 
     return ntStatus;
 }
 
-STDMETHODIMP_(USHORT) CAdapterCommon::hda_return_sound_data_format(ULONG sample_rate, ULONG channels, ULONG bits_per_sample) {
+inline STDMETHODIMP_(USHORT) CAdapterCommon::hda_return_sound_data_format(ULONG sample_rate, ULONG channels, ULONG bits_per_sample) {
  USHORT data_format = 0;
 
  //channels

--- a/common.h
+++ b/common.h
@@ -255,6 +255,13 @@ DECLARE_INTERFACE_(IAdapterCommon,IUnknown)
         IN      BYTE    Index,
         IN      BYTE    Value
     )   PURE;
+
+    STDMETHOD_(void,hda_set_volume)
+    (   THIS_
+        IN      ULONG   Volume,
+        IN      UCHAR   Channel,
+        IN      BOOLEAN Mute
+    )   PURE;
     
     STDMETHOD_(BYTE,MixerRegRead)
     (   THIS_

--- a/mintopo.cpp
+++ b/mintopo.cpp
@@ -13,6 +13,9 @@
 #define CHAN_RIGHT      1
 #define CHAN_MASTER     (-1)
 
+static BOOL MasterMuteCache = FALSE;
+
+
 
 #pragma code_seg("PAGE")
 
@@ -237,6 +240,13 @@ GetDescription
     return STATUS_SUCCESS;
 }
 
+static
+BYTE
+VolumeLevelToMixerCount
+(
+    IN      LONG    Level
+);
+
 /*****************************************************************************
  * PropertyHandler_OnOff()
  *****************************************************************************
@@ -307,6 +317,16 @@ PropertyHandler_OnOff
                                 ntStatus = STATUS_SUCCESS;
                             }
                             break;
+
+                        case LINEOUT_MUTE:  // Master Lineout Mute Control (stereo)
+                            if( ( PropertyRequest->PropertyItem->Id == KSPROPERTY_AUDIO_MUTE ) &&
+                                ( (channel == CHAN_LEFT) || (channel == CHAN_RIGHT) || (channel == CHAN_MASTER) ) )
+                            {
+                                *OnOff = MasterMuteCache;
+                                PropertyRequest->ValueSize = sizeof(BOOL);
+                                ntStatus = STATUS_SUCCESS;
+                            }
+                            break;
                     }
                 }
             }
@@ -351,13 +371,58 @@ PropertyHandler_OnOff
                                 ntStatus = STATUS_SUCCESS;
                             }
                             break;
+
+                        case LINEOUT_MUTE:  // Master Lineout Mute Control (stereo)
+                            if( ( PropertyRequest->PropertyItem->Id == KSPROPERTY_AUDIO_MUTE ) &&
+                                ( (channel == CHAN_LEFT) || (channel == CHAN_RIGHT) || (channel == CHAN_MASTER) ) )
+                            {
+                                MasterMuteCache = *(PBOOL(PropertyRequest->Value));
+
+                                if ( (channel == CHAN_LEFT) || (channel == CHAN_MASTER) )
+                                {
+                                    if (MasterMuteCache)
+                                    {
+                                        that->AdapterCommon->hda_set_volume(
+                                            that->AdapterCommon->MixerRegRead(DSP_MIX_MASTERVOLIDX_L),
+                                            1,
+                                            TRUE);
+                                    }
+                                    else
+                                    {
+                                        that->WriteBitsToMixer( DSP_MIX_MASTERVOLIDX_L,
+                                                          5,
+                                                          3,
+                                                          VolumeLevelToMixerCount(ControlValueCache[ AccessParams[LINEOUT_VOL].CacheOffset + CHAN_LEFT ]) );
+                                    }
+                                }
+                                if ( (channel == CHAN_RIGHT) || (channel == CHAN_MASTER) )
+                                {
+                                    if (MasterMuteCache)
+                                    {
+                                        that->AdapterCommon->hda_set_volume(
+                                            that->AdapterCommon->MixerRegRead(DSP_MIX_MASTERVOLIDX_R),
+                                            2,
+                                            TRUE);
+                                    }
+                                    else
+                                    {
+                                        that->WriteBitsToMixer( DSP_MIX_MASTERVOLIDX_R,
+                                                          5,
+                                                          3,
+                                                          VolumeLevelToMixerCount(ControlValueCache[ AccessParams[LINEOUT_VOL].CacheOffset + CHAN_RIGHT ]) );
+                                    }
+                                }
+                                ntStatus = STATUS_SUCCESS;
+                            }
+                            break;
                     }
                 }
             }
         } else if(PropertyRequest->Verb & KSPROPERTY_TYPE_BASICSUPPORT)
         {
             if ( ( (PropertyRequest->Node == MIC_AGC) && (PropertyRequest->PropertyItem->Id == KSPROPERTY_AUDIO_AGC) ) ||
-                 ( (PropertyRequest->Node == MIC_LINEOUT_MUTE) && (PropertyRequest->PropertyItem->Id == KSPROPERTY_AUDIO_MUTE) ) )
+                 ( (PropertyRequest->Node == MIC_LINEOUT_MUTE) && (PropertyRequest->PropertyItem->Id == KSPROPERTY_AUDIO_MUTE) ) ||
+                 ( (PropertyRequest->Node == LINEOUT_MUTE) && (PropertyRequest->PropertyItem->Id == KSPROPERTY_AUDIO_MUTE) ) )
             {
                 if(PropertyRequest->ValueSize >= (sizeof(KSPROPERTY_DESCRIPTION)))
                 {
@@ -1031,6 +1096,25 @@ PropertyHandler_CpuResources
 
 #pragma code_seg()
 
+static
+BYTE
+VolumeLevelToMixerCount
+(
+    IN      LONG    Level
+)
+{
+    if(Level <= (-62 << 16))
+    {
+        return 0;
+    }
+    if(Level >= 0)
+    {
+        return 0x1F;
+    }
+
+    return BYTE((((Level >> 16) + 62) >> 1) & 0x1F);
+}
+
 /*****************************************************************************
  * PropertyHandler_Level()
  *****************************************************************************
@@ -1151,16 +1235,7 @@ PropertyHandler_Level
                                 if(PropertyRequest->PropertyItem->Id == KSPROPERTY_AUDIO_VOLUMELEVEL)
                                 {
                                     // convert the level to register bits
-                                    if(*Level <= (-62 << 16))
-                                    {
-                                        count = 0;
-                                    } else if(*Level >= 0)
-                                    {
-                                        count = 0x1F;
-                                    } else
-                                    {
-                                        count = (((*Level >> 16) + 62) >> 1) & 0x1F;
-                                    }
+                                    count = VolumeLevelToMixerCount(*Level);
 
                                     // set right channel if channel requested is right or master
                                     // and node is not mic volume (mono)
@@ -1170,10 +1245,13 @@ PropertyHandler_Level
                                         // cache the commanded control value
                                         ControlValueCache[ AccessParams[PropertyRequest->Node].CacheOffset + CHAN_RIGHT ] = *Level;
 
-                                        that->WriteBitsToMixer( AccessParams[PropertyRequest->Node].BaseRegister+1,
-                                                          5,
-                                                          3,
-                                                          BYTE(count) );
+                                        if( (PropertyRequest->Node != LINEOUT_VOL) || !MasterMuteCache )
+                                        {
+                                            that->WriteBitsToMixer( AccessParams[PropertyRequest->Node].BaseRegister+1,
+                                                              5,
+                                                              3,
+                                                              BYTE(count) );
+                                        }
                                         ntStatus = STATUS_SUCCESS;
                                     }
                                     // set the left channel if channel requested is left or master
@@ -1182,10 +1260,13 @@ PropertyHandler_Level
                                         // cache the commanded control value
                                         ControlValueCache[ AccessParams[PropertyRequest->Node].CacheOffset + CHAN_LEFT ] = *Level;
                                         
-                                        that->WriteBitsToMixer( AccessParams[PropertyRequest->Node].BaseRegister,
-                                                          5,
-                                                          3,
-                                                          BYTE(count) );
+                                        if( (PropertyRequest->Node != LINEOUT_VOL) || !MasterMuteCache )
+                                        {
+                                            that->WriteBitsToMixer( AccessParams[PropertyRequest->Node].BaseRegister,
+                                                              5,
+                                                              3,
+                                                              BYTE(count) );
+                                        }
                                         ntStatus = STATUS_SUCCESS;
                                     }
                                 }

--- a/mintopo.cpp
+++ b/mintopo.cpp
@@ -377,41 +377,19 @@ PropertyHandler_OnOff
                                 ( (channel == CHAN_LEFT) || (channel == CHAN_RIGHT) || (channel == CHAN_MASTER) ) )
                             {
                                 MasterMuteCache = *(PBOOL(PropertyRequest->Value));
-
-                                if ( (channel == CHAN_LEFT) || (channel == CHAN_MASTER) )
-                                {
-                                    if (MasterMuteCache)
-                                    {
-                                        that->AdapterCommon->hda_set_volume(
-                                            that->AdapterCommon->MixerRegRead(DSP_MIX_MASTERVOLIDX_L),
-                                            1,
-                                            TRUE);
-                                    }
-                                    else
-                                    {
-                                        that->WriteBitsToMixer( DSP_MIX_MASTERVOLIDX_L,
-                                                          5,
-                                                          3,
-                                                          VolumeLevelToMixerCount(ControlValueCache[ AccessParams[LINEOUT_VOL].CacheOffset + CHAN_LEFT ]) );
-                                    }
-                                }
-                                if ( (channel == CHAN_RIGHT) || (channel == CHAN_MASTER) )
-                                {
-                                    if (MasterMuteCache)
-                                    {
-                                        that->AdapterCommon->hda_set_volume(
-                                            that->AdapterCommon->MixerRegRead(DSP_MIX_MASTERVOLIDX_R),
-                                            2,
-                                            TRUE);
-                                    }
-                                    else
-                                    {
-                                        that->WriteBitsToMixer( DSP_MIX_MASTERVOLIDX_R,
-                                                          5,
-                                                          3,
-                                                          VolumeLevelToMixerCount(ControlValueCache[ AccessParams[LINEOUT_VOL].CacheOffset + CHAN_RIGHT ]) );
-                                    }
-                                }
+									
+								//mute bit is the LSB of the Master Volume L & R mixer registers
+								//always set both
+								that->WriteBitsToMixer( AccessParams[PropertyRequest->Node].BaseRegister+1,
+                                                              1,
+                                                              0,
+                                                              MasterMuteCache ? 1 : 0 );
+															  
+								that->WriteBitsToMixer( AccessParams[PropertyRequest->Node].BaseRegister,
+                                                              1,
+                                                              0,
+                                                              MasterMuteCache ? 1 : 0 );
+                                
                                 ntStatus = STATUS_SUCCESS;
                             }
                             break;
@@ -1245,13 +1223,10 @@ PropertyHandler_Level
                                         // cache the commanded control value
                                         ControlValueCache[ AccessParams[PropertyRequest->Node].CacheOffset + CHAN_RIGHT ] = *Level;
 
-                                        if( (PropertyRequest->Node != LINEOUT_VOL) || !MasterMuteCache )
-                                        {
-                                            that->WriteBitsToMixer( AccessParams[PropertyRequest->Node].BaseRegister+1,
+                                        that->WriteBitsToMixer( AccessParams[PropertyRequest->Node].BaseRegister+1,
                                                               5,
                                                               3,
                                                               BYTE(count) );
-                                        }
                                         ntStatus = STATUS_SUCCESS;
                                     }
                                     // set the left channel if channel requested is left or master
@@ -1260,13 +1235,10 @@ PropertyHandler_Level
                                         // cache the commanded control value
                                         ControlValueCache[ AccessParams[PropertyRequest->Node].CacheOffset + CHAN_LEFT ] = *Level;
                                         
-                                        if( (PropertyRequest->Node != LINEOUT_VOL) || !MasterMuteCache )
-                                        {
-                                            that->WriteBitsToMixer( AccessParams[PropertyRequest->Node].BaseRegister,
+                                        that->WriteBitsToMixer( AccessParams[PropertyRequest->Node].BaseRegister,
                                                               5,
                                                               3,
                                                               BYTE(count) );
-                                        }
                                         ntStatus = STATUS_SUCCESS;
                                     }
                                 }

--- a/tables.h
+++ b/tables.h
@@ -502,6 +502,14 @@ PCNODE_DESCRIPTOR TopologyNodes[] =
         &KSAUDFNAME_MASTER_VOLUME // Name
     },
 
+    // LINEOUT_MUTE
+    {
+        0,                      // Flags
+        &AutomationMute,        // AutomationTable
+        &KSNODETYPE_MUTE,       // Type
+        &KSAUDFNAME_MASTER_MUTE // Name
+    },
+
     // LINEOUT_BASS
     {
         0,                      // Flags
@@ -596,6 +604,7 @@ ACCESS_PARM AccessParams[] =
 
     { 0,                            ULONG(-1)   },      // LINEOUT_MIX
     { DSP_MIX_MASTERVOLIDX_L,       10          },      // LINEOUT_VOL
+    { 0,                            ULONG(-1)   },      // LINEOUT_MUTE
     { DSP_MIX_BASSIDX_L,            12          },      // LINEOUT_BASS
     { DSP_MIX_TREBLEIDX_L,          14          },      // LINEOUT_TREBLE
     { DSP_MIX_OUTGAINIDX_L,         16          },      // LINEOUT_GAIN
@@ -621,6 +630,7 @@ enum
     MIC_WAVEIN_SUPERMIX,
     LINEOUT_MIX,
     LINEOUT_VOL,
+    LINEOUT_MUTE,
     LINEOUT_BASS,
     LINEOUT_TREBLE,
     LINEOUT_GAIN,
@@ -688,7 +698,8 @@ PCCONNECTION_DESCRIPTOR MiniportConnections[] =
     {   MIC_WAVEIN_SUPERMIX,    0,                WAVEIN_MIX,             4             },
 
     {   LINEOUT_MIX,            0,                LINEOUT_VOL,            1             },
-    {   LINEOUT_VOL,            0,                LINEOUT_BASS,           1             },
+    {   LINEOUT_VOL,            0,                LINEOUT_MUTE,           1             },
+    {   LINEOUT_MUTE,           0,                LINEOUT_BASS,           1             },
     {   LINEOUT_BASS,           0,                LINEOUT_TREBLE,         1             },
     {   LINEOUT_TREBLE,         0,                LINEOUT_GAIN,           1             },
     {   LINEOUT_GAIN,           0,                PCFILTER_NODE,          LINEOUT_DEST  },


### PR DESCRIPTION
### Motivation

- Provide explicit master mute support in the topology and ensure mute state is honored when setting codec gains and volumes to avoid unintentionally clearing codec mute bits.

### Description

- Introduced a `mute` flag to `hda_set_volume` and `hda_set_node_gain` APIs across `HDA_Codec`, `CAdapterCommon` and headers so callers can request codec mute behavior (`BOOLEAN mute`).
- Reworked gain payload calculation in `hda_set_node_gain` to compute the level range first and set the codec mute bit only when `mute` is true or when gain==0 and the codec advertises mute support, preserving correct mute semantics.
- Updated initialization call sites in `codec.cpp` to pass `FALSE` for the new `mute` parameter so initialization does not accidentally mute outputs.
- Added topology master mute support by adding a `LINEOUT_MUTE` node in `tables.h`, a `MasterMuteCache` and `VolumeLevelToMixerCount` helper in `mintopo.cpp`, and GET/SET handling for `KSPROPERTY_AUDIO_MUTE` to apply cached master mute state and drive `AdapterCommon->hda_set_volume(..., TRUE)` when muting.
- Propagated the new `mute` parameter through `common.h`/`common.cpp` so `CAdapterCommon::hda_set_volume` delegates include the mute behavior.

### Testing

- Built the driver solution (including modified `codec`, `common`, and `mintopo` files) as an automated build; compilation succeeded with no errors.
- Performed automated rebuilds of both codec and adapter modules to verify API/ABI changes; builds succeeded.
- No automated unit tests exist for audio topology properties in this tree, so testing was limited to automated compilation/verifications above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a400f6f5a188323bd6fa0db79dff74a)